### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
     - cadvisor
   cadvisor:
-    image: gcr.io/google-containers/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor
     container_name: cadvisor
     ports:
     - 8080:8080


### PR DESCRIPTION
```
gcr.io/google-containers/cadvisor:latest
```

Mentioned image causes following issue when tried to run, please do visit the issue page of google cadvisor to know more about the issue.

[cadvisor docker container fails to start "mountpoint for cpu not found" ](https://github.com/google/cadvisor/issues/1943)

Solution mentioned here was to use,

```
gcr.io/cadvisor/cadvisor
```